### PR TITLE
Introduce journal page

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,8 @@ import Config
 config :notebook,
   generators: [timestamp_type: :utc_datetime],
   notebook_path: "~/.notebook/default",
-  notes_folder: "notes"
+  notes_dir: "notes",
+  journals_dir: "journals"
 
 # Configures the endpoint
 config :notebook, NotebookWeb.Endpoint,

--- a/lib/notebook/config.ex
+++ b/lib/notebook/config.ex
@@ -1,6 +1,10 @@
 defmodule Notebook.Config do
   def notes_path() do
-    [notebook_path(), notes_folder()] |> expand_path()
+    [fetch!(:notebook_path), fetch!(:notes_dir)] |> expand_path()
+  end
+
+  def journals_path() do
+    [fetch!(:notebook_path), fetch!(:journals_dir)] |> expand_path()
   end
 
   defp expand_path(path) do
@@ -9,11 +13,7 @@ defmodule Notebook.Config do
     |> Path.expand()
   end
 
-  def notebook_path() do
-    Application.fetch_env!(:notebook, :notebook_path)
-  end
-
-  defp notes_folder() do
-    Application.fetch_env!(:notebook, :notes_folder)
+  defp fetch!(key) do
+    Application.fetch_env!(:notebook, key)
   end
 end

--- a/lib/notebook/journals.ex
+++ b/lib/notebook/journals.ex
@@ -1,0 +1,70 @@
+defmodule Notebook.Journals do
+  alias Notebook.FileSystem
+  alias Notebook.Config
+
+  @moduledoc """
+  The Journals context.
+  """
+
+  @doc """
+  Gets a list of journals whitin notebook, sorted by date in descending order
+
+  ## Examples
+
+      iex> Journals.list_journals()
+      [
+        {~D[2024-02-06], "/Users/rastasheep/.notebook/default/journals/2024_02_06.md"},
+        {~D[2024-02-04], "/Users/rastasheep/.notebook/default/journals/2024_02_04.md"}
+      ]
+  """
+
+  def list_journals() do
+    Config.journals_path()
+    |> FileSystem.list()
+    |> Enum.map(&parse_file_name_to_date/1)
+    |> Enum.filter(&valid_date?/1)
+    |> Enum.sort_by(&elem(&1, 0), {:desc, Date})
+  end
+
+  @doc """
+  Gets a single journal.
+
+  Raises if the Journal does not exist.
+
+  ## Examples
+
+      iex> Journals.get_journal!(:html, '2024_02_06.md')
+      "<h1>Note-content</h1>"
+
+      iex> Journals.get_journal!('2024_02_06.md')
+      "# Note-content"
+  """
+
+  def get_journal(:html, journal) do
+    get_journal(journal)
+    |> Earmark.as_html!()
+  end
+
+  def get_journal(journal) do
+    Config.journals_path()
+    |> Path.join(journal)
+    |> FileSystem.read()
+  end
+
+  def get_relative_path(path) do
+    Path.relative_to(path, Config.journals_path())
+  end
+
+  defp parse_file_name_to_date(file_path) do
+    file_name = Path.basename(file_path, Path.extname(file_path))
+    file_name = String.replace(file_name, "_", "-")
+
+    case Date.from_iso8601(file_name) do
+      {:ok, date} -> {date, file_path}
+      {:error, :invalid_format} -> {:error}
+    end
+  end
+
+  defp valid_date?({:error}), do: false
+  defp valid_date?(_), do: true
+end

--- a/lib/notebook/notes.ex
+++ b/lib/notebook/notes.ex
@@ -7,24 +7,45 @@ defmodule Notebook.Notes do
   """
 
   @doc """
+  Gets a list of notes whitin notebook
+
+  ## Examples
+
+      iex> Notes.list_notes()
+      [
+        {"test.md", "/Users/rastasheep/.notebook/default/notes/test.md"},
+        {"proj/another.md", "/Users/rastasheep/.notebook/default/notes/proj/another.md"
+      ]
+  """
+
+  def list_notes() do
+    Config.notes_path()
+    |> FileSystem.list()
+    |> Enum.map(fn p -> {Path.relative_to(p, Config.notes_path()), p} end)
+  end
+
+  @doc """
   Gets a single note.
 
   Raises if the Note does not exist.
 
   ## Examples
 
-      iex> get_note!(:html, 'index.md')
-      %Note{}
+      iex> Notes.get_note!(:html, 'index.md')
+      "<h1>Note-content</h1>"
 
+      iex> Notes.get_note!('index.md')
+      "# Note-content"
   """
-  def get_note!(format, note) do
+
+  def get_note!(:html, note) do
+    get_note!(note)
+    |> Earmark.as_html!()
+  end
+
+  def get_note!(note) do
     Config.notes_path()
     |> Path.join(note)
     |> FileSystem.read()
-    |> parse(format)
-  end
-
-  defp parse(note, :html) do
-    Earmark.as_html!(note)
   end
 end

--- a/lib/notebook_web/commands.ex
+++ b/lib/notebook_web/commands.ex
@@ -3,8 +3,7 @@ defmodule NotebookWeb.Commands do
 
   import Phoenix.LiveView
 
-  alias Notebook.Config
-  alias Notebook.FileSystem
+  alias Notebook.Notes
 
   def score(string) do
     list_commands()
@@ -29,10 +28,9 @@ defmodule NotebookWeb.Commands do
   end
 
   defp open_note_commands() do
-    Config.notes_path()
-    |> FileSystem.list()
-    |> Enum.map(fn path ->
-      {:nav_to, name: String.replace(path, "#{Config.notes_path()}/", ""), icon: "hero-document"}
+    Notes.list_notes()
+    |> Enum.map(fn {name, _path} ->
+      {:nav_to, name: name, icon: "hero-document"}
     end)
   end
 

--- a/lib/notebook_web/components/layouts/root.html.heex
+++ b/lib/notebook_web/components/layouts/root.html.heex
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
-<html lang="en" class="[scrollbar-gutter:stable] dark">
+<html
+  lang="en"
+  class={[
+    "[scrollbar-gutter:stable] dark",
+    if(assigns[:infinite], do: "[scrollbar-width:none]")
+  ]}
+>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -11,7 +17,7 @@
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
-  <body class="bg-white dark:bg-zinc-900 antialiased selection:bg-sky-200 dark:selection:text-zinc-900 scroll-smooth">
+  <body class="bg-white text-zinc-700 dark:bg-zinc-900 antialiased dark:text-zinc-300 selection:bg-sky-200 dark:selection:text-zinc-900 scroll-smooth">
     <%= @inner_content %>
   </body>
 </html>

--- a/lib/notebook_web/live/journal_live/index.ex
+++ b/lib/notebook_web/live/journal_live/index.ex
@@ -1,0 +1,63 @@
+defmodule NotebookWeb.JournalLive.Index do
+  use NotebookWeb, :live_view
+
+  alias Notebook.Journals
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Journals")
+     |> assign(:infinite, true)
+     |> assign(page: 1, per_page: 5)
+     |> stream_configure(:journals, dom_id: fn {name, _, _} -> name end)
+     |> assign(:journal_index, Journals.list_journals())
+     |> paginate(1)}
+  end
+
+  @impl true
+  def handle_event("next-page", _, socket) do
+    {:noreply, paginate(socket, socket.assigns.page + 1)}
+  end
+
+  def handle_event("prev-page", %{"_overran" => true}, socket) do
+    {:noreply, paginate(socket, 1)}
+  end
+
+  def handle_event("prev-page", _, socket) do
+    if socket.assigns.page > 1 do
+      {:noreply, paginate(socket, socket.assigns.page - 1)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp paginate(socket, new_page) when new_page >= 1 do
+    %{per_page: per_page, page: cur_page, journal_index: journal_index} = socket.assigns
+
+    journals =
+      Enum.slice(journal_index, (new_page - 1) * per_page, per_page)
+      |> Enum.map(fn {name, path} ->
+        content = Journals.get_journal(:html, Journals.get_relative_path(path))
+        {name, path, content}
+      end)
+
+    {journals, at, limit} =
+      if new_page >= cur_page do
+        {journals, -1, per_page * 3 * -1}
+      else
+        {Enum.reverse(journals), 0, per_page * 3}
+      end
+
+    case journals do
+      [] ->
+        assign(socket, end_of_timeline?: at == -1)
+
+      [_ | _] = journals ->
+        socket
+        |> assign(end_of_timeline?: false)
+        |> assign(:page, new_page)
+        |> stream(:journals, journals, at: at, limit: limit)
+    end
+  end
+end

--- a/lib/notebook_web/live/journal_live/index.html.heex
+++ b/lib/notebook_web/live/journal_live/index.html.heex
@@ -1,0 +1,46 @@
+<div class="fixed z-10 flex items-center bottom-2 left-1/2 transform -translate-x-1/2 p-2 bg-white/90 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 rounded-xl">
+  <div class="pl-2 border-r border-zinc-300 flex items-center">
+    <%= @page_title %>
+
+    <.link href="#top" class="mx-2 flex items-center">
+      <.icon name="hero-arrow-up-mini" />
+    </.link>
+  </div>
+
+  <.link class="flex items-center" phx-click="toggle" phx-target="#commands">
+    <.icon name="hero-magnifying-glass-mini" class="mx-2" />
+  </.link>
+</div>
+
+<div class="flex relative w-full py-6">
+  <div
+    id="journals"
+    phx-update="stream"
+    phx-viewport-top={@page > 1 && "prev-page"}
+    phx-viewport-bottom={!@end_of_timeline? && "next-page"}
+    class={[
+      "grow mt-8 px-6 md:max-w-6xl md:mx-auto divide-y divide-solid divide-zinc-300 dark:divide-zinc-700",
+      if(@end_of_timeline?, do: "", else: ""),
+      if(@page == 1, do: "", else: "")
+    ]}
+  >
+    <article
+      :for={{id, {name, _, content}} <- @streams.journals}
+      class="xl:mx-auto prose prose-zinc dark:prose-invert py-8 first:pt-0 break-words hyphens-auto"
+      id={id}
+    >
+      <h1><%= Calendar.strftime(name, "%B %d, %Y") %></h1>
+      <%= raw(content) %>
+    </article>
+
+    <h1 :if={@end_of_timeline?} class="py-10 mt-5 text-center">
+      -fin-
+    </h1>
+  </div>
+  <!-- <a class="block my-4 text-zinc-700 dark:text-zinc-300" href>July 31, 2024</a> -->
+  <div class="w-[200px] ml-[-200px] pr-3 text-right text-zinc-300 dark:text-zinc-700 hidden lg:block">
+    <a :for={{name, _path} <- @journal_index} class="block">
+      <%= Calendar.strftime(name, "%B %d, %Y") %>
+    </a>
+  </div>
+</div>

--- a/lib/notebook_web/live/note_live/show.html.heex
+++ b/lib/notebook_web/live/note_live/show.html.heex
@@ -1,4 +1,4 @@
-<div class="fixed z-10 flex items-center bottom-2 left-1/2 transform -translate-x-1/2 p-2 bg-white/90 dark:bg-zinc-800 dark:text-zinc-300 border border-zinc-300 dark:border-zinc-700 rounded-xl">
+<div class="fixed z-10 flex items-center bottom-2 left-1/2 transform -translate-x-1/2 p-2 bg-white/90 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 rounded-xl">
   <div class="pl-2 border-r border-zinc-300 flex items-center">
     <%= @page_title %>
 
@@ -13,7 +13,7 @@
 </div>
 
 <div class="relative w-full p-6 md:max-w-6xl md:mx-auto">
-  <article class="mt-8 mx-auto prose prose-zinc dark:prose-invert">
+  <article class="mt-8 mx-auto prose prose-zinc dark:prose-invert break-words hyphens-auto">
     <%= raw(@note) %>
   </article>
 </div>

--- a/lib/notebook_web/router.ex
+++ b/lib/notebook_web/router.ex
@@ -19,6 +19,7 @@ defmodule NotebookWeb.Router do
 
     get "/", PageController, :home
 
+    live "/journals", JournalLive.Index, :index
     live "/notes/:id", NoteLive.Show, :show
   end
 


### PR DESCRIPTION
As a user,
I would like to view a page listing all my journal entries,
so that I can easily browse through my past journal notes.

The journal entries page should list all entries, one per day.
Each entry on the list should render full note.
The page should support infinite scrolling to allow viewing older entries without manual page refreshes.
The UI should provide visual feedback while older entries are being loaded.

![image](https://github.com/rastasheep/notebook/assets/695790/f9b5d370-7d5e-4be0-8901-a7bd4973e850)
