### PR TITLE
Introduce journal show page

### DIFF
--- a/lib/notebook/file_system.ex
+++ b/lib/notebook/file_system.ex
@@ -2,12 +2,12 @@ defmodule Notebook.FileSystem do
   def read(path) do
     path
     |> ensure_extension(".md")
-    |> File.read!()
+    |> File.read()
   end
 
-  def list(path) do
+  def list(path, glob \\ "**/*.*") do
     path
-    |> Path.join("**/*.*")
+    |> Path.join(glob)
     |> Path.wildcard()
   end
 

--- a/lib/notebook/notes.ex
+++ b/lib/notebook/notes.ex
@@ -32,18 +32,20 @@ defmodule Notebook.Notes do
   ## Examples
 
       iex> Notes.get_note!(:html, 'index.md')
-      "<h1>Note-content</h1>"
+      {:ok, "<h1>Note-content</h1>"}
 
       iex> Notes.get_note!('index.md')
-      "# Note-content"
+      {:ok, "# Note-content"}
   """
 
-  def get_note!(:html, note) do
-    get_note!(note)
-    |> Earmark.as_html!()
+  def get_note(:html, note) do
+    case get_note(note) do
+      {:ok, content} -> {:ok, Earmark.as_html!(content)}
+      {:error, error} -> {:error, error}
+    end
   end
 
-  def get_note!(note) do
+  def get_note(note) do
     Config.notes_path()
     |> Path.join(note)
     |> FileSystem.read()

--- a/lib/notebook_web/live/journal_live/index.ex
+++ b/lib/notebook_web/live/journal_live/index.ex
@@ -10,7 +10,7 @@ defmodule NotebookWeb.JournalLive.Index do
      |> assign(:page_title, "Journals")
      |> assign(:infinite, true)
      |> assign(page: 1, per_page: 5)
-     |> stream_configure(:journals, dom_id: fn {name, _, _} -> name end)
+     |> stream_configure(:journals, dom_id: fn {date, _, _} -> date end)
      |> assign(:journal_index, Journals.list_journals())
      |> paginate(1)}
   end
@@ -37,9 +37,9 @@ defmodule NotebookWeb.JournalLive.Index do
 
     journals =
       Enum.slice(journal_index, (new_page - 1) * per_page, per_page)
-      |> Enum.map(fn {name, path} ->
-        content = Journals.get_journal(:html, Journals.get_relative_path(path))
-        {name, path, content}
+      |> Enum.map(fn {date, path} ->
+        {:ok, content} = Journals.get_journal(:html, date)
+        {date, path, content}
       end)
 
     {journals, at, limit} =

--- a/lib/notebook_web/live/journal_live/index.html.heex
+++ b/lib/notebook_web/live/journal_live/index.html.heex
@@ -25,11 +25,15 @@
     ]}
   >
     <article
-      :for={{id, {name, _, content}} <- @streams.journals}
+      :for={{id, {date, _, content}} <- @streams.journals}
       class="xl:mx-auto prose prose-zinc dark:prose-invert py-8 first:pt-0 break-words hyphens-auto"
       id={id}
     >
-      <h1><%= Calendar.strftime(name, "%B %d, %Y") %></h1>
+      <h1 class="not-prose">
+        <.link navigate={~p'/journals/#{Date.to_string(date)}'}>
+          <%= Calendar.strftime(date, "%B %d, %Y") %>
+        </.link>
+      </h1>
       <%= raw(content) %>
     </article>
 
@@ -39,8 +43,10 @@
   </div>
   <!-- <a class="block my-4 text-zinc-700 dark:text-zinc-300" href>July 31, 2024</a> -->
   <div class="w-[200px] ml-[-200px] pr-3 text-right text-zinc-300 dark:text-zinc-700 hidden lg:block">
-    <a :for={{name, _path} <- @journal_index} class="block">
-      <%= Calendar.strftime(name, "%B %d, %Y") %>
+    <a :for={{date, _path} <- @journal_index} class="block">
+      <.link navigate={~p'/journals/#{Date.to_string(date)}'}>
+        <%= Calendar.strftime(date, "%B %d, %Y") %>
+      </.link>
     </a>
   </div>
 </div>

--- a/lib/notebook_web/live/journal_live/show.ex
+++ b/lib/notebook_web/live/journal_live/show.ex
@@ -1,0 +1,32 @@
+defmodule NotebookWeb.JournalLive.Show do
+  use NotebookWeb, :live_view
+
+  alias Notebook.Journals
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    case Journals.parse_file_name_to_date(id) do
+      {date, _} ->
+        d = Calendar.strftime(date, "%B %d, %Y")
+
+        case Journals.get_journal(:html, date) do
+          {:ok, journal} ->
+            {:noreply,
+             socket
+             |> assign(:page_title, d)
+             |> assign(:journal, journal)}
+
+          {:error, _} ->
+            {:noreply, redirect(socket, to: ~p"/journals")}
+        end
+
+      {:error} ->
+        {:noreply, redirect(socket, to: ~p"/journals")}
+    end
+  end
+end

--- a/lib/notebook_web/live/journal_live/show.html.heex
+++ b/lib/notebook_web/live/journal_live/show.html.heex
@@ -1,0 +1,21 @@
+<div class="fixed z-10 flex items-center bottom-2 left-1/2 transform -translate-x-1/2 p-2 bg-white/90 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 rounded-xl">
+  <div class="pl-2 border-r border-zinc-300 flex items-center">
+    <%= @page_title %>
+
+    <.link href="#top" class="mx-2 flex items-center">
+      <.icon name="hero-arrow-up-mini" />
+    </.link>
+  </div>
+
+  <.link class="flex items-center" phx-click="toggle" phx-target="#commands">
+    <.icon name="hero-magnifying-glass-mini" class="mx-2" />
+  </.link>
+</div>
+
+<div class="relative w-full p-6 md:max-w-6xl md:mx-auto">
+  <article class="mt-8 mx-auto prose prose-zinc dark:prose-invert break-words hyphens-auto">
+    <h1><%= @page_title %></h1>
+
+    <%= raw(@journal) %>
+  </article>
+</div>

--- a/lib/notebook_web/live/note_live/show.ex
+++ b/lib/notebook_web/live/note_live/show.ex
@@ -10,9 +10,15 @@ defmodule NotebookWeb.NoteLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
-    {:noreply,
-     socket
-     |> assign(:page_title, id)
-     |> assign(:note, Notes.get_note!(:html, id))}
+    case Notes.get_note(:html, id) do
+      {:ok, note} ->
+        {:noreply,
+         socket
+         |> assign(:page_title, id)
+         |> assign(:note, note)}
+
+      {:error, _} ->
+        {:noreply, redirect(socket, to: ~p"/")}
+    end
   end
 end

--- a/lib/notebook_web/router.ex
+++ b/lib/notebook_web/router.ex
@@ -20,6 +20,8 @@ defmodule NotebookWeb.Router do
     get "/", PageController, :home
 
     live "/journals", JournalLive.Index, :index
+    live "/journals/:id", JournalLive.Show, :show
+
     live "/notes/:id", NoteLive.Show, :show
   end
 


### PR DESCRIPTION
As a user,
I would like to open a specific journal entry by clicking on it from the journal entries list,
so that I can focus on the details of that day's entry in full.

Clicking on a journal entry in the list should open the entry on a new page.
The specific journal entry page should render the full note in a readable format.
The URL for each journal day's entry page should be unique and directly navigable.
The note should support standard formatting, same as regular notes.

![image](https://github.com/rastasheep/notebook/assets/695790/2c942efd-915f-4299-86d3-6f06b9572f65)
