### PR TITLE
Add command for opening all journals and next journal

### DIFF
--- a/lib/notebook_web/commands.ex
+++ b/lib/notebook_web/commands.ex
@@ -23,7 +23,8 @@ defmodule NotebookWeb.Commands do
 
   defp editor_commands() do
     [
-      {:nav_away, name: "Clap along", icon: "hero-face-smile"}
+      {:nav_journal, name: "Journals", icon: "hero-book-open"},
+      {:nav_journal_next, name: "Journals › Next", icon: "hero-book-open"}
     ]
   end
 
@@ -38,7 +39,11 @@ defmodule NotebookWeb.Commands do
     push_navigate(socket, to: ~p"/notes/#{context[:name]}")
   end
 
-  def handle_command(:nav_away, _context, socket) do
-    push_navigate(socket, to: ~p"/#away")
+  def handle_command(:nav_journal, _context, socket) do
+    push_navigate(socket, to: ~p"/journals")
+  end
+
+  def handle_command(:nav_journal_next, _context, socket) do
+    push_navigate(socket, to: ~p"/journals/#{Date.utc_today() |> Date.add(1)}")
   end
 end

--- a/lib/notebook_web/live/journal_live/index.html.heex
+++ b/lib/notebook_web/live/journal_live/index.html.heex
@@ -30,7 +30,7 @@
       id={id}
     >
       <h1 class="not-prose">
-        <.link navigate={~p'/journals/#{Date.to_string(date)}'}>
+        <.link navigate={~p'/journals/#{date}'}>
           <%= Calendar.strftime(date, "%B %d, %Y") %>
         </.link>
       </h1>
@@ -44,7 +44,7 @@
   <!-- <a class="block my-4 text-zinc-700 dark:text-zinc-300" href>July 31, 2024</a> -->
   <div class="w-[200px] ml-[-200px] pr-3 text-right text-zinc-300 dark:text-zinc-700 hidden lg:block">
     <a :for={{date, _path} <- @journal_index} class="block">
-      <.link navigate={~p'/journals/#{Date.to_string(date)}'}>
+      <.link navigate={~p'/journals/#{date}'}>
         <%= Calendar.strftime(date, "%B %d, %Y") %>
       </.link>
     </a>

--- a/lib/notebook_web/router.ex
+++ b/lib/notebook_web/router.ex
@@ -46,3 +46,9 @@ defmodule NotebookWeb.Router do
     end
   end
 end
+
+defimpl Phoenix.Param, for: Date do
+  def to_param(date) do
+    Date.to_iso8601(date)
+  end
+end


### PR DESCRIPTION
As a user,
I would like to open the journal entries page and individual journal days' entries via the command palette,
so that I can quickly navigate to them using keyboard shortcuts.

The command palette should include an option to open journal.
~The command palette should allow opening current journal entry.~
The command palette should allow opening next journal entry.
Upon selecting these options, the appropriate page should be opened directly.

![image](https://github.com/rastasheep/notebook/assets/695790/594ec85b-f5b9-4db9-8f04-730d8feb9d9e)
